### PR TITLE
Update Dockerfile with Playwright install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ COPY --from=builder /app/package-lock.json ./package-lock.json
 
 # Install production dependencies
 RUN npm ci --ignore-scripts --omit=dev
+RUN npx playwright install
 
 # Set the command to run the server
 ENTRYPOINT ["node", "dist/index.js"]


### PR DESCRIPTION
There seems to be a bug when trying to use the Dockerized MCP due to a missing dependency in the build.

![image](https://github.com/user-attachments/assets/4bb891a6-e540-448b-a9e1-4f5c5a4fb433)

Here's a suggested change, but I don't know this MCP that well so I recommend you verify if this is the missing dependency.