### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ A Model Context Protocol server that provides browser automation capabilities us
 
 > This is a fork of [executeautomation/mcp-playwright](https://github.com/executeautomation/mcp-playwright) v0.2.7, enhanced with CDP support for connecting to running Chrome instances.
 
+<a href="https://glama.ai/mcp/servers/fdvu5n58kv"><img width="380" height="200" src="https://glama.ai/mcp/servers/fdvu5n58kv/badge" alt="Playwright CDP MCP server" /></a>
+
 ## Key Features
 
 - 🔗 Connect to existing Chrome instances via CDP


### PR DESCRIPTION
This PR adds a badge for the [MCP Playwright CDP](https://glama.ai/mcp/servers/fdvu5n58kv) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/fdvu5n58kv"><img width="380" height="200" src="https://glama.ai/mcp/servers/fdvu5n58kv/badge" alt="Playwright CDP MCP server" /></a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.