### PR TITLE
reconnect in case of "context or browser has been closed" error

### DIFF
--- a/src/toolsHandler.ts
+++ b/src/toolsHandler.ts
@@ -18,7 +18,20 @@ type ViewportSize = {
   height?: number;
 };
 
+
 async function ensureBrowser(viewport?: ViewportSize) {
+  // Check if the browser connection is still active
+  if (page) {
+    try {
+      await page!.title();
+    } catch (e : any) {
+      if (e.message.includes('browser has been closed')) {
+        console.error('Connection to browser lost, reconnect...');
+        browser = undefined;
+      }
+    }
+  }
+
   if (!browser) {
     try {
       // First try to connect to existing Chrome instance


### PR DESCRIPTION
This pull request includes an enhancement to the `ensureBrowser` function in the `src/toolsHandler.ts` file. The change ensures that the function checks if the browser connection is still active before attempting to use it, and handles the reconnection if the connection is lost.
